### PR TITLE
Drop support for Python 2.4, 2.5, 3.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: python
 python:
   - "2.6"
   - "2.7"
-  - "3.2"
   - "3.3"
   - "3.4"
   - "3.5-dev"

--- a/NEWS
+++ b/NEWS
@@ -5,6 +5,13 @@ testresources release notes
 IN DEVELOPMENT
 --------------
 
+CHANGES
+~~~~~~~
+
+* Drop support for Python 2.4, 2.5, 3.2: while not deliberately breaking
+  compatibility, we cannot easily test those in CI, so stating that they
+  are supported is at best misleading. (Robert Collins)
+
 IMPROVEMENTS
 ~~~~~~~~~~~~
 

--- a/README
+++ b/README
@@ -28,7 +28,7 @@ enterprise applications, or web servers ... let imagination run wild.
 Dependencies to build/selftest
 ==============================
 
-* Python 2.4+ (or 3.2+)
+* Python 2.6+ (or 3.3+)
 * docutils
 * testtools (http://pypi.python.org/pypi/testtools/)
 * fixtures (http://pypi.python.org/pypi/fixtures)
@@ -36,7 +36,10 @@ Dependencies to build/selftest
 Dependencies to use testresources
 =================================
 
-* Python 2.4+ (or 3.2+)
+* Python 2.6+ (or 3.3+)
+
+For older versions of Python, testresources <= 1.0.0 supported 2.4, 2.5 and
+3.2.
 
 How testresources Works
 =======================

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,6 +13,7 @@ classifiers =
     License :: OSI Approved :: Apache Software License
     Operating System :: OS Independent
     Programming Language :: Python
+    Programming Language :: Python :: 2
     Programming Language :: Python :: 3
     Topic :: Software Development :: Quality Assurance
     Topic :: Software Development :: Testing


### PR DESCRIPTION
While not deliberately breaking compatibility, we cannot easily test
those in CI, so stating that they are supported is at best misleading.
