### PR TITLE
Skip flaky testBasicSortTests on Python 3.x

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -20,6 +20,7 @@ classifier =
 
 [extras]
 test =
+    six
     docutils
     fixtures
     testtools

--- a/testresources/tests/test_optimising_test_suite.py
+++ b/testresources/tests/test_optimising_test_suite.py
@@ -15,6 +15,7 @@
 #  license.
 #
 
+import six
 import testtools
 import random
 import testresources
@@ -498,6 +499,7 @@ class TestGraphStuff(testtools.TestCase):
         permutations.append([case4, case1, case3, case2])
         return permutations
 
+    @unittest2.skipIf(six.PY3, "Flaky on Python 3, see LP #1645008")
     def testBasicSortTests(self):
         # Test every permutation of inputs, with legacy tests.
         # Cannot use equal costs because of the use of


### PR DESCRIPTION
Temporary stop-gap for a flaky test on Python 3.x, see:

https://bugs.launchpad.net/testresources/+bug/1645008