### PR TITLE
Point Travis to pypy3 version 5.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ python:
   - "3.4"
   - "3.5-dev"
   - "pypy"
-  - "pypy3"
+  - "pypy3.3-5.2-alpha1"
   - "nightly"
 
 install:


### PR DESCRIPTION
The default pypy3 version in Travis is 2.4.0, which implements the
Python 3.2.x API.

Since setuptools recently dropped support for 3.0-3.2, the pypy3
builds for testresources are broken.

This branch changes the pypy3 Travis target to use pypy3.3-5.2-alpha1
instead.