### PR TITLE
skip testBasicSortTests in general

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -20,7 +20,6 @@ classifier =
 
 [extras]
 test =
-    six
     docutils
     fixtures
     testtools

--- a/testresources/tests/test_optimising_test_suite.py
+++ b/testresources/tests/test_optimising_test_suite.py
@@ -15,7 +15,6 @@
 #  license.
 #
 
-import six
 import testtools
 import random
 import testresources
@@ -538,7 +537,7 @@ class TestGraphStuff(testtools.TestCase):
         permutations.append([case4, case1, case3, case2])
         return permutations
 
-    @unittest2.skipIf(six.PY3, "Flaky on Python 3, see LP #1645008")
+    @testtools.skip("Flaky on Python 2/3, see LP #1645008")
     def testBasicSortTests(self):
         # Test every permutation of inputs, with legacy tests.
         # Cannot use equal costs because of the use of


### PR DESCRIPTION
Expanding on our current Python3-specific disable: I'm also seeing this test fail randomly, in exactly the same way, on Python 2.7.15 (custom Linux 4.16.18).  FWIW it seems to fail most commonly on 32-bit ARM (soft and hard float) and AArch64-ILP32; I have yet to see it fail on AArch64 or x86[-64].

Also, let's consistently use testtools skip decorators.  We aren't even guaranteed to have unittest2 if we don't put it in the reqs, and other test code is already supposed to cope with this gracefully.