### PR TITLE
Add support to Python 3.10

### DIFF
--- a/testresources/__init__.py
+++ b/testresources/__init__.py
@@ -20,7 +20,10 @@
 import heapq
 import inspect
 import unittest
-import collections
+try:
+    from collections.abc import MutableSet
+except ImportError:
+    from collections import MutableSet
 try:
     import unittest2
 except ImportError:
@@ -192,7 +195,7 @@ def _strongly_connected_components(graph, no_resources):
     return partitions
 
 
-class _OrderedSet(collections.MutableSet):
+class _OrderedSet(MutableSet):
     """This is taken from the OrderedSet recipe link in the Python 2 docs.
 
     See:

--- a/testresources/tests/test_optimising_test_suite.py
+++ b/testresources/tests/test_optimising_test_suite.py
@@ -538,7 +538,7 @@ class TestGraphStuff(testtools.TestCase):
         permutations.append([case4, case1, case3, case2])
         return permutations
 
-    @unittest2.skipIf(six.PY3, "Flaky on Python 3, see LP #1645008")
+    @testtools.skipIf(six.PY3, "Flaky on Python 3, see LP #1645008")
     def testBasicSortTests(self):
         # Test every permutation of inputs, with legacy tests.
         # Cannot use equal costs because of the use of


### PR DESCRIPTION
This is done by addressing the changes introduced in clollections [1] and using testtools to skip tests instead of unittest2, which does not support python 3.10 yet.

[1] https://docs.python.org/3/whatsnew/3.10.html#removed