### PR TITLE
Refactor failIf to assertFalse for Python 3.12 Compatibility

### DIFF
--- a/testresources/tests/test_resourced_test_case.py
+++ b/testresources/tests/test_resourced_test_case.py
@@ -129,7 +129,7 @@ class TestResourcedTestCase(testtools.TestCase):
         self.resourced_case.resources = [("foo", self.resource_manager)]
         self.resourced_case.setUpResources()
         self.resourced_case.tearDownResources()
-        self.failIf(hasattr(self.resourced_case, "foo"))
+        self.assertFalse(hasattr(self.resourced_case, "foo"))
 
     def testTearDownResourcesStopsUsingResource(self):
         # tearDownResources records that there is one less use of each
@@ -158,5 +158,5 @@ class TestResourcedTestCase(testtools.TestCase):
         self.assertEqual(self.resourced_case.foo, self.resource)
         self.assertEqual(self.resource_manager._uses, 1)
         self.resourced_case.tearDown()
-        self.failIf(hasattr(self.resourced_case, "foo"))
+        self.assertFalse(hasattr(self.resourced_case, "foo"))
         self.assertEqual(self.resource_manager._uses, 0)


### PR DESCRIPTION
This commit replaces deprecated `failIf` calls with `assertFalse` in the `test_resourced_test_case.py` file. The `failIf` method was removed in Python 3.12 [1-3].

[1] https://docs.python.org/3.12/whatsnew/3.12.html#removed
[2] https://github.com/python/cpython/issues/89325
[3] https://github.com/python/cpython/pull/28268