### PR TITLE
Add tests to source distribution

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,6 +67,7 @@ include = [
     "GOALS",
     "Makefile",
     "NEWS",
+    "tests*",
     "TODO",
     "tox.ini",
 ]


### PR DESCRIPTION
Fix regression introduced in 385319e5be5f32b where moving the test suite caused it to no longer be included in source distribution.  Fixes https://bugs.launchpad.net/testresources/+bug/2149769.